### PR TITLE
BGE-3  replaced the Pyrénées Software name Index.html files

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -89,7 +89,7 @@
 						<h2>Contactez nous</h2>
 						<ul class="page-title-link">
 							<li><a href="#">SIGSCAN</a></li>
-							<li><a href="#">Par Pyrénées Software</a></li>
+							<li><a href="#">Par Sigscan</a></li>
 						</ul>
 					</div>
 				</div>
@@ -143,7 +143,7 @@
 							<i class="icon icon-location2"></i>
 						</div>
 						<h3>Adresse</h3>
-						<p>Pyrénées Software<br>
+						<p>Sigscan<br>
                                                    22 rue Hermès<br>
                                                    31520 RAMONVILLE SAINT AGNE</p>
 					</div>
@@ -152,7 +152,7 @@
 							<i class="fa fa-envelope" aria-hidden="true"></i>
 						</div>
 						<h3>Email</h3>
-						<p><br><br>contact@pyrenees-software.com</p>
+						<p><br><br>contact@sigscan.eu</p>
 					</div>
 					<div class="address-item">
 						<div class="address-icon">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <meta name="description" content="Sigscan est une solution de géolocalisation de materiels industriels, simple et abordable.
     Grâce à des cartes Bluetooth autonome en énergie et des antennes installées aux bons endroits dans les batiments,
     vous suivez et retrouvez facilement votre materiel depuis votre mobile ou votre ordinateur.">
-    <meta name="author" content="Pyrénées Software">
+    <meta name="author" content="Sigscan">
 
     <meta name="og:type" content="website">
     <meta name="og:url" content="https://www.sigscan.eu">
@@ -157,13 +157,13 @@
             <div class="col-md-6">
                 <div class="message-box">
                     <h4>Qui sommes nous ?</h4>
-                    <h2>SIGSCAN, une technologie conçue par Pyrénées Software</h2>
+                    <h2>SIGSCAN, une technologie conçue par Sigscan</h2>
 
-                    <P>Pyrénées Software est une société spécialisée dans la création de logiciels informatiques à
+                    <P>Sigscan est une société spécialisée dans la création de logiciels informatiques à
                         destination des industriels. Elle intervient notamment dans la création d’outils informatiques
                         de gestion des usines, de maintenance des machines, de gestion des stocks…<br>
 
-                        Pyrénées Software s’est aussi spécialisée dans les applications mobiles et propose aujourd’hui à
+                        Sigscan s’est aussi spécialisée dans les applications mobiles et propose aujourd’hui à
                         ses clients, le développement d’applications mobiles « outils ».<br>
 
                         C’est donc au contact des industriels que l’idée d’une solution de géolocalisation indoor s’est
@@ -171,7 +171,7 @@
                     </p>
 
                     <p>Accéder au site :</p>
-                    <a href="https://www.pyrenees-software.com/"><img src="uploads/pslogo.png" alt=""
+                    <a href="https://www.sigscan.eu"><img src="images/logolongblFichier 3.png" alt=""
                                                                       class="img-responsive img-rounded pslogo"></a>
                 </div><!-- end messagebox -->
             </div><!-- end col -->
@@ -285,7 +285,7 @@
             <div class="col-md-6">
                 <div class="customwidget text-left">
                     <h1>Interface Web</h1>
-                    <p>L'interface Web développée par Pyrénées Software vous permet de retrouver vos objets dans vos
+                    <p>L'interface Web développée par Sigscan vous permet de retrouver vos objets dans vos
                         bâtiments à l'aide d'une carte.</p>
                     <p>Elle est adaptable, évolutive et personnalisable selon vos envies. <br> Sa simplicité
                         d'utilisation fait d'elle une force.</p>
@@ -336,8 +336,8 @@
                     <div class="widget-title">
                         <h3>Contact</h3>
                         <p>Adresse : 22 rue Hermès <br> 31520 Ramonville Saint-Agne</p>
-                        <p>téléphone : 05 82 95 90 86</p>
-                        <p>Mail : contact@pyrenees-software.com</p>
+                        <p>téléphone : 05 82 95 90 85</p>
+                        <p>Mail : contact@sigscan.eu</p>
                     </div>
 
                 </div><!-- end clearfix -->

--- a/portfolio.html
+++ b/portfolio.html
@@ -101,7 +101,7 @@
         <div class="container">
             <div class="section-title text-center">
                 <h3>Produits</h3>
-                <p class="lead">Pyrénées Software ne fabrique pas les beacons <br> mais est en étroite relation avec des fournisseurs vous assurant <br> une gamme de modèles qui répondent au mieux à vos besoins.</p>
+                <p class="lead">Sigscan ne fabrique pas les beacons <br> mais est en étroite relation avec des fournisseurs vous assurant <br> une gamme de modèles qui répondent au mieux à vos besoins.</p>
             </div><!-- end title -->
         </div><!-- end container -->
             <hr class="invis">
@@ -238,7 +238,7 @@
                 <p class="justify">
                     ⦁	Les « Beacons » (balises) Bluetooth qui sont les systèmes à géolocaliser : Ils existent sur le marché en différents formats.<br>
                     ⦁	Ils sont autonomes et fonctionnent avec des piles remplaçable ou pas (selon les modèles) ayant un autonomie pouvant aller jusqu’à 3 ans (selon les cas d’utilisation) <br>
-                    ⦁	Les antennes « Gateways » Bluetooth, à installer aux endroits stratégiques d’un bâtiment, qui réceptionnent les signaux Bluetooth et les retransmettent par Wifi/Ethernet/CPL à un serveur dédié (Data Retriever) installé chez le Client ou sur le Cloud de Pyrénées Software.<br>
+                    ⦁	Les antennes « Gateways » Bluetooth, à installer aux endroits stratégiques d’un bâtiment, qui réceptionnent les signaux Bluetooth et les retransmettent par Wifi/Ethernet/CPL à un serveur dédié (Data Retriever) installé chez le Client ou sur le Cloud de Sigscan.<br>
                     ⦁	Un serveur de calcul « Data Retriever » traitant les signaux Bluetooth qui lui sont transmis et calculant les positions des beacons <br>
                     ⦁	Une base de données central « Back-End », en charge de stocker toutes les données, les positions des objets, la configuration du système … <br>
                     ⦁	Une interface Web « Front-End » permettant à l’utilisateur de géolocaliser visuellement sur une carte du bâtiment les objets recherchés depuis son ordinateur. <br>

--- a/services.html
+++ b/services.html
@@ -407,7 +407,7 @@
                             <h3>Contact</h3>
                             <p>Adresse : 22 rue Hermès <br> 31520 Ramonville Saint-Agne</p>
                             <p>téléphone : 05 82 95 90 85</p>
-                            <p>Mail : contact@pyrenees-software.com</p>
+                            <p>Mail : contact@sigscan.eu</p>
                         </div>
                     </div><!-- end clearfix -->
                 </div><!-- end col -->


### PR DESCRIPTION
We change Index.html
We have replaced the Pyrénées Software name and logo by Sigscan.
We have also changed the links and replaced with the current site link sigscan.eu.
We change correctly the meta name (="author" content="Pyrenes Software") by (meta name="author" content="Sigscan")
